### PR TITLE
Viewing TC subproject builds grouped by project name

### DIFF
--- a/src/components/TeamcityTableComponent/TeamcityTableComponent.tsx
+++ b/src/components/TeamcityTableComponent/TeamcityTableComponent.tsx
@@ -16,13 +16,13 @@ export const buildUrl = (build: Partial<BuildType>) => {
   const LinkWrapper = () => {
     const routeLink = useRouteRef(buildRouteRef);
     return (
-      <Link
-        to={routeLink({
-          buildName: String(build.name),
-          buildId: String(build.id)
-        })}>
-        {build.name}
-      </Link>
+        <Link
+            to={routeLink({
+              buildName: String(build.name),
+              buildId: String(build.id)
+            })}>
+          {build.name}
+        </Link>
     );
   }
 
@@ -33,16 +33,16 @@ export const buildLogUrl = (build: Partial<BuildType>, buildRunId?: string) => {
   const LinkWrapper = () => {
     const routeLink = useRouteRef(buildLogsRouteRef);
     return buildRunId ? (
-      <Link
-      style={{float:'left'}}
-        to={routeLink({
-          buildName: String(build.name),
-          buildId: String(build.id),
-          buildRunId: String(buildRunId)
-        })}>
-        (view logs)
-      </Link>
-      ) : (<></>);
+        <Link
+            style={{float:'left'}}
+            to={routeLink({
+              buildName: String(build.name),
+              buildId: String(build.id),
+              buildRunId: String(buildRunId)
+            })}>
+          (view logs)
+        </Link>
+    ) : (<></>);
   }
 
   return <LinkWrapper />;
@@ -50,7 +50,7 @@ export const buildLogUrl = (build: Partial<BuildType>, buildRunId?: string) => {
 
 export const DenseTable = ({ builds }: DenseTableProps) => {
   const columns: TableColumn[] = [
-    { 
+    {
       title: 'Name',
       field: 'name',
       highlight: true,
@@ -78,35 +78,76 @@ export const DenseTable = ({ builds }: DenseTableProps) => {
       const revisions = build?.builds?.build[0]?.revisions?.revision;
       revision = build?.builds?.build[0]?.revisions?.revision[revisions.length-1];
     }
-    
+
     return {
       id: build.id,
       name: build.name,
+      projectName: build.projectName,
+      projectId: build.projectId,
       branchName: (<TeamcitySource revision={revision} branchName={branchName}/>),
       status: (
-        <>
-          <TeamcityStatus status={build?.builds?.build[0]?.status} statusText={build?.builds?.build[0]?.statusText} />
-          {buildLogUrl(build, buildRunId)}
-        </>
+          <>
+            <TeamcityStatus status={build?.builds?.build[0]?.status} statusText={build?.builds?.build[0]?.statusText} />
+            {buildLogUrl(build, buildRunId)}
+          </>
       ),
       finishedAt: `${finishedAt}`,
       webUrl: (
-        <Link
-          to={build.webUrl}
-          target="_blank"
-        ><Launch fontSize="small"/></Link>
+          <Link
+              to={build.webUrl}
+              target="_blank"
+          ><Launch fontSize="small"/></Link>
       ),
     };
   });
 
-  return (
-    <Table
-      title="Builds"
-      options={{ search: false, paging: false }}
-      columns={columns}
-      data={data}
-    />
-  );
+  // group builds by projectId and show table for each TC subproject
+  const projectNames = new Map<string, string>();
+  const groupedBuildsMap = data.reduce<Map<string, typeof data>>((acc, build) => {
+    const projectId = build.projectId || "";
+    const projectName = build.projectName || "";
+
+    if (!acc.has(projectId)) {
+      acc.set(projectId, [build]);
+    } else {
+      acc.get(projectId)?.push(build)
+    }
+
+    projectNames.set(projectId, projectName);
+    return acc;
+  }, new Map<string, typeof data>());
+
+
+  const items: JSX.Element[] = [];
+  groupedBuildsMap.forEach((value, projectIdKey) => {
+    const projectName = projectNames.get(projectIdKey) || ""; // every subproject level is separated by '/'
+    const lastSlashIndex = projectName.lastIndexOf("/");
+    let beforeLastPart, lastPart;
+
+    if (lastSlashIndex > 0) {
+      beforeLastPart = projectName.slice(0, lastSlashIndex).trim();
+      lastPart = projectName.slice(lastSlashIndex + 1).trim();
+    } else {
+      beforeLastPart = "";
+      lastPart = projectName.trim();
+    }
+
+    items.push(
+        <>
+          <Table
+              title={lastPart}
+              subtitle={beforeLastPart}
+              options={{search: false, paging: false}}
+              columns={columns}
+              data={value}/>
+          <br/>
+        </>
+    );
+  });
+
+  return (<>
+    {items}
+  </>)
 };
 
 /** @public */
@@ -115,7 +156,7 @@ export const TeamcityTableComponent = () => {
   const config = useApi(configApiRef);
   const { value, loading, error } = useAsync(async (): Promise<BuildType[]> => {
     const backendUrl = config.getString('backend.baseUrl');
-    const fieldsQuery = 'buildType(id,name,webUrl,builds($locator(running:false,count:1),build(id,number,status,statusText,branchName,revisions(revision(version,vcsBranchName,vcs-root-instance)),startDate,finishDate)))';
+    const fieldsQuery = 'buildType(id,name,projectId,projectName,webUrl,builds($locator(running:false,count:1),build(id,number,status,statusText,branchName,revisions(revision(version,vcsBranchName,vcs-root-instance)),startDate,finishDate)))';
     const response = await fetch(`${backendUrl}/api/proxy/teamcity-proxy/app/rest/buildTypes?locator=affectedProject:(id:${entity.metadata.annotations?.[TEAMCITY_ANNOTATION]})&fields=${fieldsQuery}`);
     const data = await response.json();
 

--- a/src/components/TeamcityTableComponent/TeamcityTableComponent.tsx
+++ b/src/components/TeamcityTableComponent/TeamcityTableComponent.tsx
@@ -122,7 +122,7 @@ export const DenseTable = ({ builds }: DenseTableProps) => {
   groupedBuildsMap.forEach((value, projectIdKey) => {
     const projectName = projectNames.get(projectIdKey) || ""; // every subproject level is separated by '/'
     const lastSlashIndex = projectName.lastIndexOf("/");
-    let beforeLastPart, lastPart;
+    let beforeLastPart; let lastPart;
 
     if (lastSlashIndex > 0) {
       beforeLastPart = projectName.slice(0, lastSlashIndex).trim();

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -16,6 +16,8 @@ export type BuildCollection = {
 export type BuildType = {
   id: string;
   name: string;
+  projectId: string;
+  projectName: string;
   status?: string;
   webUrl: string;
   builds: {


### PR DESCRIPTION
TeamCity supports subprojects and it can contain a build with a same name (existing in another subproject) , but current view mix all build names together (see screenshot). This PR groups builds by project name (same as TC does).
See images for comparison - with this code you can recognize to which project the build belongs to:

### Before
![before](https://user-images.githubusercontent.com/2512959/235658630-a8739a70-81df-4a76-b440-033b1b7312b3.png)

### After
![after](https://user-images.githubusercontent.com/2512959/235658495-27f594a5-0f9b-4f96-955c-f0817c1cb49e.png)
